### PR TITLE
Update tradePairParser.js

### DIFF
--- a/src/modules/tradePairParser.js
+++ b/src/modules/tradePairParser.js
@@ -124,10 +124,16 @@ class TradePairParser {
           resolve([]);
           return;
         }
-
-        let collectedData = [];
-        collectedData.strategy = config.pairs[market][tradePair].strategy || '';
-        resolve(collectedData);
+        
+        try {
+          let collectedData = [];
+          collectedData.strategy = config.pairs[market][tradePair].strategy || '';
+          resolve(collectedData);
+        } catch (e) {
+          resolve([]);
+          return;
+        }
+        
       });
     });
   }


### PR DESCRIPTION
Fix Error when old traded pair state file existed but is not longer being traded so config file didn't have a "strategy" to reference.

gunbot-monitor-master/src/modules/tradePairParser.js:130
        collectedData.strategy = config.pairs[market][tradePair].strategy || '';
TypeError: Cannot read property 'strategy' of undefined
    at fs.stat.error (/gunbot-monitor-master/src/modules/tradePairParser.js:130:65)